### PR TITLE
Add localization module with localized_gladefile function

### DIFF
--- a/usr/lib/python3/dist-packages/mintcommon/__init__.py
+++ b/usr/lib/python3/dist-packages/mintcommon/__init__.py
@@ -1,4 +1,4 @@
 
 """Collection of classes shared by Mint packages."""
 
-__all__ = ["aptdaemon", "installer", "apt_changelog", "additionalfiles"]
+__all__ = ["aptdaemon", "installer", "apt_changelog", "additionalfiles", "localization"]

--- a/usr/lib/python3/dist-packages/mintcommon/localization.py
+++ b/usr/lib/python3/dist-packages/mintcommon/localization.py
@@ -1,0 +1,21 @@
+def localized_gladefile(gladefile, gettext):
+    """ Returns localized contents of gladefile
+
+    Parameters:
+        gladefile: Path to glade file
+        gettext: Callback to gettext.gettext() / _()
+
+    Workaround for Gtk.Builder/GLib.dgettext creating encoding issues in non-UTF-8
+    environments. It translates all translatable strings in the gladefile via the
+    gettext callback before you pass it to Gtk.Builder.
+
+    Usage:
+        builder = Gtk.Builder.new_from_string(localized_gladefile(gladefile, _), -1)
+    """
+    from xml.etree import ElementTree
+    tree = ElementTree.parse(gladefile)
+    for node in tree.iter():
+        if "translatable" in node.attrib:
+            del node.attrib["translatable"]
+            node.text = gettext(node.text)
+    return ElementTree.tostring(tree.getroot(), encoding="unicode", method="xml")


### PR DESCRIPTION
Workaround for Gtk.Builder/GLib.dgettext creating encoding issues in non-UTF-8 environments. 