### PR TITLE
_flatpak.py: Add missing gi.require_version()

### DIFF
--- a/usr/lib/python3/dist-packages/mintcommon/installer/_flatpak.py
+++ b/usr/lib/python3/dist-packages/mintcommon/installer/_flatpak.py
@@ -8,7 +8,7 @@ import tempfile
 import os
 
 import gi
-gi.require_version('AppStream', '1.0')
+gi.require_version('AppStreamGlib', '1.0')
 gi.require_version('Gtk', '3.0')
 from gi.repository import AppStreamGlib, GLib, GObject, Gtk, Gio
 


### PR DESCRIPTION
Think this was just overlooked in https://github.com/linuxmint/mintcommon/commit/c1620d4b57a201abe0679b4a8cbc36e59c3d8728