### PR TITLE
Missing a closing tag, getting parsing error

### DIFF
--- a/usr/share/polkit-1/actions/com.linuxmint.mintcommon.policy
+++ b/usr/share/polkit-1/actions/com.linuxmint.mintcommon.policy
@@ -17,3 +17,4 @@
     <annotate key="org.freedesktop.policykit.exec.path">/usr/lib/linuxmint/common/mint-remove-application.py</annotate>
     <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
   </action>
+</policyconfig>


### PR DESCRIPTION
Look like it is missing a closing tag, getting parsing error when running polkitd without '--no-debug'

` Error parsing file with URI 'file:///usr/share/polkit-1/actions/com.linuxmint.mintcommon.policy': 20: parse error: no element found
`
With the tag the error parsing error is gone

```
# sudo systemctl status polkit                                     
● polkit.service - Authorization Manager
     Loaded: loaded (/lib/systemd/system/polkit.service; static; vendor preset: enabled)
     Active: active (running) since Fri 2022-02-04 10:52:39 CET; 3min 43s ago
       Docs: man:polkit(8)
   Main PID: 16699 (polkitd)
      Tasks: 3 (limit: 38254)
     Memory: 7.5M
     CGroup: /system.slice/polkit.service
             └─16699 /usr/lib/policykit-1/polkitd

Feb 04 10:52:39 SDSNB64 polkitd[16699]: Acquired the name org.freedesktop.PolicyKit1

Feb 04 10:52:49 SDSNB64 polkitd[16699]: Error parsing file with URI 'file:///usr/share/polkit-1/actions/com.linuxmint.mintcommon.policy': 20: parse error: no element found

Feb 04 10:52:49 SDSNB64 polkitd(authority=local)[16699]: Registered Authentication Agent for unix-process:16797:339996 (system bus name :1.224 [pkexec /usr/bin/mintsources], object path /org/freedesktop/PolicyKit1/AuthenticationAgent, locale en_US.UTF-8)
Feb 04 10:52:49 SDSNB64 polkitd[16699]: Error parsing identity unix-group:admin: No UNIX group with name admin: Success
Feb 04 10:53:00 SDSNB64 polkitd(authority=local)[16699]: Operator of unix-process:16797:339996 FAILED to authenticate to gain authorization for action com.linuxmint.mintsources for unix-process:16797:339996 [/usr/bin/python3 /usr/bin/software-sources] (owned by unix-user:stefan)
Feb 04 10:53:00 SDSNB64 polkitd(authority=local)[16699]: Unregistered Authentication Agent for unix-process:16797:339996 (system bus name :1.224, object path /org/freedesktop/PolicyKit1/AuthenticationAgent, locale en_US.UTF-8)
Feb 04 10:56:10 SDSNB64 polkitd(authority=local)[16699]: Registered Authentication Agent for unix-process:17236:360081 (system bus name :1.226 [pkexec /usr/bin/mintsources], object path /org/freedesktop/PolicyKit1/AuthenticationAgent, locale en_US.UTF-8)
Feb 04 10:56:10 SDSNB64 polkitd[16699]: Error parsing identity unix-group:admin: No UNIX group with name admin: Success
Feb 04 10:56:16 SDSNB64 polkitd(authority=local)[16699]: Operator of unix-process:17236:360081 FAILED to authenticate to gain authorization for action com.linuxmint.mintsources for unix-process:17236:360081 [/usr/bin/python3 /usr/bin/software-sources] (owned by unix-user:stefan)
Feb 04 10:56:16 SDSNB64 polkitd(authority=local)[16699]: Unregistered Authentication Agent for unix-process:17236:360081 (system bus name :1.226, object path /org/freedesktop/PolicyKit1/AuthenticationAgent, locale en_US.UTF-8)
```