### PR TITLE
prevent NameError in process_full_apt_cache

### DIFF
--- a/usr/lib/python3/dist-packages/mintcommon/installer/_apt.py
+++ b/usr/lib/python3/dist-packages/mintcommon/installer/_apt.py
@@ -117,11 +117,11 @@ def process_full_apt_cache(cache):
             else:
                 section = section_string
 
-        try:
-            sections[section].append(pkg_hash)
-        except Exception:
-            sections[section] = []
-            sections[section].append(pkg_hash)
+            try:
+                sections[section].append(pkg_hash)
+            except Exception:
+                sections[section] = []
+                sections[section].append(pkg_hash)
 
         cache[pkg_hash] = AptPkgInfo(pkg_hash, pkg)
 


### PR DESCRIPTION
The variable `section` is only defined in the if statement `if pkg.candidate:`, so the call to `sections[section]` should only be made in the if statement.

Currently the code will fail if the `pkg.candidate` is false.