### PR TITLE
Fixed dependency bug with libreoffice-style-colibre

### DIFF
--- a/usr/lib/python3/dist-packages/mintcommon/installer/_apt.py
+++ b/usr/lib/python3/dist-packages/mintcommon/installer/_apt.py
@@ -20,7 +20,7 @@ from . import dialogs
 
 # List extra packages that aren't necessarily marked in their control files, but
 # we know better...
-CRITICAL_PACKAGES = ["mint-common", "mint-translations", "mint-meta-core", "mintdesktop", "python3", "perl"]
+CRITICAL_PACKAGES = ["mint-common", "mint-translations", "mint-meta-core", "mintdesktop", "python3", "perl", "libreoffice-style-colibre"]
 
 def capitalize(string):
     if len(string) > 1:


### PR DESCRIPTION
The same problem like this: https://github.com/linuxmint/mint21.2-beta/issues/42
![dependency](https://github.com/linuxmint/mintcommon/assets/23406555/51d4ffda-34b9-46b2-98e4-7d1f0ef99b01)
